### PR TITLE
Adds note that 13 models are available at the top of every cmip6 xray items.

### DIFF
--- a/explorer/components/XrayIntroblurb.vue
+++ b/explorer/components/XrayIntroblurb.vue
@@ -12,7 +12,8 @@ const props = defineProps(['resolution', 'unit', 'cmip', 'beta'])
       <li v-if="cmip == 5">NCAR CCSM4, MRI CGCM3, etc&hellip; these are the names of climate models.</li>
       <li v-if="cmip == 6">SSP1-2.5, SSP2-4.5 etc… these are socioeconomic and emission scenarios. <a href="https://glisa.umich.edu/wp-content/uploads/2021/03/A_Practitioners_Guide_to_Climate_Model_Scenarios.pdf">&#x2192; read more</a></li>
       <li v-if="cmip == 5">RCP 4.5, RCP 8.5... these are representative concentration pathways representing emissions scenarios.</li>
-      <li>the spatial resolution of this dataset is {{ resolution }}&#8239;{{ unit }}</li>
+      <li v-if="cmip == 6">There are <NuxtLink to="/item/story-arctic-climate-data-node">thirteen scenarios</NuxtLink> included in this dataset, and up to four different models.  Not all models have all scenarios available.</li>
+      <li>the spatial resolution of this dataset is <strong>{{ resolution }}&#8239;{{ unit }}</strong>.</li>
     </ul>
   </blockquote>
 </template>

--- a/explorer/components/global/StoryArcticClimateDataNode.vue
+++ b/explorer/components/global/StoryArcticClimateDataNode.vue
@@ -140,7 +140,7 @@ onMounted(() => {
             <strong>
               <span class="bling">CMIP6</span> models and scenarios that perform
               best in Alaska and the pan&ndash;Arctic: </strong
-            >These include 12 global climate models, 4 emissions scenarios, and
+            >These include 13 global climate models, 4 emissions scenarios, and
             18 variables. Compared to prior CMIP5 data housed at UAF, the CMIP6
             data available through the ACDN offers more models and more
             variables, while representing the current state-of-the-art climate


### PR DESCRIPTION
Closes #50 

Testing:

 - Go to a CMIP6 (coarse resolution) x-ray item such as this one: http://localhost:3000/item/sea-ice-cmip6
 - Check that there's a line item addressing the number of models.
 - Click through to the page that is the overview/intro for the Arctic Climate Data node, that used to say "There are 12 models..." (see code diff) but fixed to 13.
