### PR TITLE
Adds community names to chart titles and filename of downloaded charts

### DIFF
--- a/explorer/components/Cmip6MonthlyChart.vue
+++ b/explorer/components/Cmip6MonthlyChart.vue
@@ -171,11 +171,7 @@ const buildChart = () => {
       {
         title: {
           text:
-            props.label +
-            ' for ' +
-            placesStore.latLng?.lat +
-            ', ' +
-            placesStore.latLng?.lng +
+            chartStore.getChartTitle(props.label) +
             '<br />' +
             'Model: ' +
             chartLabels.value.models[chartInputs.value.model] +
@@ -215,6 +211,11 @@ const buildChart = () => {
           'autoScale2d',
           'resetScale2d',
         ],
+        toImageButtonOptions: {
+          format: 'png',
+          filename: chartStore.getChartTitle(props.label),
+          scale: 2,
+        },
       }
     )
   }

--- a/explorer/components/Cmip6MonthlyChart.vue
+++ b/explorer/components/Cmip6MonthlyChart.vue
@@ -165,59 +165,25 @@ const buildChart = () => {
       yAxisLabel += ' (' + props.units + ')'
     }
 
-    $Plotly.newPlot(
-      chartId.value,
-      traces,
-      {
-        title: {
-          text:
-            chartStore.getChartTitle(props.label) +
-            '<br />' +
-            'Model: ' +
-            chartLabels.value.models[chartInputs.value.model] +
-            ', Scenario: ' +
-            chartLabels.value.scenarios[chartInputs.value.scenario] +
-            ', Month: ' +
-            chartLabels.value.months[chartInputs.value.month],
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          tickangle: 45,
-        },
-        yaxis: {
-          title: {
-            text: yAxisLabel,
-            font: {
-              size: 18,
-            },
-          },
-          range: [min, max],
-          fixedrange: true,
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-        toImageButtonOptions: {
-          format: 'png',
-          filename: chartStore.getChartTitle(props.label),
-          scale: 2,
-        },
-      }
-    )
+    const chartTitle = chartStore.getChartTitle(props.label)
+
+    const titleText: string =
+      chartTitle +
+      '<br />' +
+      'Model: ' +
+      chartLabels.value.models[chartInputs.value.model] +
+      ', Scenario: ' +
+      chartLabels.value.scenarios[chartInputs.value.scenario] +
+      ', Month: ' +
+      chartLabels.value.months[chartInputs.value.month]
+
+    const layout = getLayout(titleText, yAxisLabel, {
+      tickangle: 45,
+    })
+
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot(chartId.value, traces, layout, config)
   }
 }
 

--- a/explorer/components/DegreeDaysChart.vue
+++ b/explorer/components/DegreeDaysChart.vue
@@ -12,6 +12,7 @@ import { precisionMean } from '~/utils/math'
 const { $Plotly, $_ } = useNuxtApp()
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
+const chartStore = useChartStore()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
@@ -169,12 +170,7 @@ const buildChart = () => {
       traces,
       {
         title: {
-          text:
-            props.label +
-            ' for ' +
-            placesStore.latLng?.lat +
-            ', ' +
-            placesStore.latLng?.lng,
+          text: chartStore.getChartTitle(props.label),
           font: {
             size: 24,
           },
@@ -208,6 +204,11 @@ const buildChart = () => {
           'autoScale2d',
           'resetScale2d',
         ],
+        toImageButtonOptions: {
+          format: 'png',
+          filename: chartStore.getChartTitle(props.label),
+          scale: 2,
+        },
       }
     )
   }

--- a/explorer/components/DegreeDaysChart.vue
+++ b/explorer/components/DegreeDaysChart.vue
@@ -165,52 +165,21 @@ const buildChart = () => {
       })
     })
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text: chartStore.getChartTitle(props.label),
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          // Pad x-axis with one null to avoid overlapping y-axis line.
-          tickvals: [null].concat($_.range(1, allDecades.length)),
-          ticktext: allDecades,
-          dtick: 1,
-        },
-        yaxis: {
-          title: {
-            text: props.label + ' (°F⋅days)',
-            font: {
-              size: 18,
-            },
-          },
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-        toImageButtonOptions: {
-          format: 'png',
-          filename: chartStore.getChartTitle(props.label),
-          scale: 2,
-        },
-      }
-    )
+    const titleText = chartStore.getChartTitle(props.label)
+
+    const xAxis = {
+      // Pad x-axis with one null to avoid overlapping y-axis line.
+      tickvals: [null].concat($_.range(1, allDecades.length)),
+      ticktext: allDecades,
+      dtick: 1,
+    }
+
+    const yAxisLabel = props.label + ' (°F⋅days)'
+
+    const layout = getLayout(titleText, yAxisLabel, xAxis)
+    const config = getConfig(titleText)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/components/HydrologyChart.vue
+++ b/explorer/components/HydrologyChart.vue
@@ -81,11 +81,7 @@ const buildChart = () => {
       {
         title: {
           text:
-            props.label +
-            ' for ' +
-            placesStore.latLng?.lat +
-            ', ' +
-            placesStore.latLng?.lng +
+            chartStore.getChartTitle(props.label) +
             '<br />' +
             'Model: ' +
             chartLabels.value.models[chartInputs.value.model] +
@@ -123,6 +119,11 @@ const buildChart = () => {
           'autoScale2d',
           'resetScale2d',
         ],
+        toImageButtonOptions: {
+          format: 'png',
+          filename: chartStore.getChartTitle(props.label),
+          scale: 2,
+        },
       }
     )
   }

--- a/explorer/components/HydrologyChart.vue
+++ b/explorer/components/HydrologyChart.vue
@@ -75,57 +75,25 @@ const buildChart = () => {
       yAxisLabel += ' (' + props.units + ')'
     }
 
-    $Plotly.newPlot(
-      chartId.value,
-      traces,
-      {
-        title: {
-          text:
-            chartStore.getChartTitle(props.label) +
-            '<br />' +
-            'Model: ' +
-            chartLabels.value.models[chartInputs.value.model] +
-            ', Scenario: ' +
-            chartLabels.value.scenarios[chartInputs.value.scenario] +
-            ', Month: ' +
-            chartLabels.value.months[chartInputs.value.month],
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          tickangle: 45,
-        },
-        yaxis: {
-          title: {
-            text: yAxisLabel,
-            font: {
-              size: 18,
-            },
-          },
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-        toImageButtonOptions: {
-          format: 'png',
-          filename: chartStore.getChartTitle(props.label),
-          scale: 2,
-        },
-      }
-    )
+    const chartTitle = chartStore.getChartTitle(props.label)
+
+    const titleText =
+      chartTitle +
+      '<br />' +
+      'Model: ' +
+      chartLabels.value.models[chartInputs.value.model] +
+      ', Scenario: ' +
+      chartLabels.value.scenarios[chartInputs.value.scenario] +
+      ', Month: ' +
+      chartLabels.value.months[chartInputs.value.month]
+
+    const layout = getLayout(titleText, yAxisLabel, {
+      tickangle: 45,
+    })
+
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot(chartId.value, traces, layout, config)
   }
 }
 

--- a/explorer/components/IndicatorsChart.vue
+++ b/explorer/components/IndicatorsChart.vue
@@ -12,6 +12,7 @@ import type { Data } from 'plotly.js-dist-min'
 const { $Plotly, $_ } = useNuxtApp()
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
+const chartStore = useChartStore()
 
 const scenarioInput = defineModel({ default: 'rcp85' })
 
@@ -151,11 +152,7 @@ const buildChart = () => {
       {
         title: {
           text:
-            props.label +
-            ' for ' +
-            placesStore.latLng?.lat +
-            ', ' +
-            placesStore.latLng?.lng +
+            chartStore.getChartTitle(props.label) +
             '<br />' +
             'Scenario: ' +
             scenarioLabels[scenarioInput.value],
@@ -192,6 +189,11 @@ const buildChart = () => {
           'autoScale2d',
           'resetScale2d',
         ],
+        toImageButtonOptions: {
+          format: 'png',
+          filename: chartStore.getChartTitle(props.label),
+          scale: 2,
+        },
       }
     )
   }

--- a/explorer/components/IndicatorsChart.vue
+++ b/explorer/components/IndicatorsChart.vue
@@ -146,56 +146,22 @@ const buildChart = () => {
       yAxisLabel += ' (' + props.units + ')'
     }
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text:
-            chartStore.getChartTitle(props.label) +
-            '<br />' +
-            'Scenario: ' +
-            scenarioLabels[scenarioInput.value],
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          // Pad x-axis with one null to avoid overlapping y-axis line.
-          tickvals: ([null] as Array<number | null>).concat(ticks),
-          ticktext: [''].concat(eraLabels),
-          dtick: 1,
-        },
-        yaxis: {
-          title: {
-            text: yAxisLabel,
-            font: {
-              size: 18,
-            },
-          },
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-        toImageButtonOptions: {
-          format: 'png',
-          filename: chartStore.getChartTitle(props.label),
-          scale: 2,
-        },
-      }
-    )
+    const chartTitle = chartStore.getChartTitle(props.label)
+
+    const titleText: string =
+      chartTitle + '<br />' + 'Scenario: ' + scenarioLabels[scenarioInput.value]
+
+    const xAxis = {
+      // Pad x-axis with one null to avoid overlapping y-axis line.
+      tickvals: ([null] as Array<number | null>).concat(ticks),
+      ticktext: [''].concat(eraLabels),
+      dtick: 1,
+    }
+
+    const layout = getLayout(titleText, yAxisLabel, xAxis)
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/components/IndicatorsCmip6Chart.vue
+++ b/explorer/components/IndicatorsCmip6Chart.vue
@@ -204,59 +204,27 @@ const buildChart = () => {
       yAxisLabel += ' (' + props.units + ')'
     }
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text:
-            chartStore.getChartTitle(props.label) +
-            '<br />Model: ' +
-            chartInputs.value.model +
-            ', Scenario: ' +
-            chartLabels.value.scenarios[chartInputs.value.scenario],
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          // Pad x-axis with one null to avoid overlapping y-axis line.
-          tickvals: [null].concat($_.range(1, allDecades.length)),
-          ticktext: [''].concat(allDecades),
-          dtick: 1,
-        },
-        yaxis: {
-          title: {
-            text: yAxisLabel,
-            font: {
-              size: 18,
-            },
-          },
-          range: [min, max],
-          fixedrange: true,
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-        toImageButtonOptions: {
-          format: 'png',
-          filename: chartStore.getChartTitle(props.label),
-          scale: 2,
-        },
-      }
-    )
+    const chartTitle = chartStore.getChartTitle(props.label)
+
+    const titleText: string =
+      chartTitle +
+      '<br />' +
+      'Model: ' +
+      chartLabels.value.models[chartInputs.value.model] +
+      ', Scenario: ' +
+      chartLabels.value.scenarios[chartInputs.value.scenario]
+
+    const xAxis = {
+      // Pad x-axis with one null to avoid overlapping y-axis line.
+      tickvals: [null].concat($_.range(1, allDecades.length)),
+      ticktext: [''].concat(allDecades),
+      dtick: 1,
+    }
+
+    const layout = getLayout(titleText, yAxisLabel, xAxis)
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/components/IndicatorsCmip6Chart.vue
+++ b/explorer/components/IndicatorsCmip6Chart.vue
@@ -210,11 +210,7 @@ const buildChart = () => {
       {
         title: {
           text:
-            props.label +
-            ' for ' +
-            placesStore.latLng?.lat +
-            ', ' +
-            placesStore.latLng?.lng +
+            chartStore.getChartTitle(props.label) +
             '<br />Model: ' +
             chartInputs.value.model +
             ', Scenario: ' +
@@ -254,6 +250,11 @@ const buildChart = () => {
           'autoScale2d',
           'resetScale2d',
         ],
+        toImageButtonOptions: {
+          format: 'png',
+          filename: chartStore.getChartTitle(props.label),
+          scale: 2,
+        },
       }
     )
   }

--- a/explorer/components/PermafrostChart.vue
+++ b/explorer/components/PermafrostChart.vue
@@ -155,7 +155,9 @@ const buildChart = () => {
       })
     })
 
-    let titleText: string = chartStore.getChartTitle(props.label)
+    const chartTitle = chartStore.getChartTitle(props.label)
+
+    let titleText = chartTitle
 
     if (props.depth) {
       titleText += '<br />Depth: ' + props.depth + ', '
@@ -165,52 +167,19 @@ const buildChart = () => {
 
     titleText += 'Scenario: ' + chartInputs.value.scenario
 
-    $Plotly.newPlot(
-      chartId.value,
-      traces,
-      {
-        title: {
-          text: titleText,
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          // Pad x-axis with one null to avoid overlapping y-axis line.
-          tickvals: [null].concat($_.range(1, allDecades.length)),
-          ticktext: allDecades,
-          dtick: 1,
-        },
-        yaxis: {
-          title: {
-            text: props.label + ' (' + props.units + ')',
-            font: {
-              size: 18,
-            },
-          },
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-        toImageButtonOptions: {
-          format: 'png',
-          filename: titleText,
-          scale: 2,
-        },
-      }
-    )
+    const yAxisLabel = props.label + ' (' + props.units + ')'
+
+    const xAxis = {
+      // Pad x-axis with one null to avoid overlapping y-axis line.
+      tickvals: [null].concat($_.range(1, allDecades.length)),
+      ticktext: allDecades,
+      dtick: 1,
+    }
+
+    const layout = getLayout(titleText, yAxisLabel, xAxis)
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot(chartId.value, traces, layout, config)
   }
 }
 

--- a/explorer/components/PermafrostChart.vue
+++ b/explorer/components/PermafrostChart.vue
@@ -155,12 +155,7 @@ const buildChart = () => {
       })
     })
 
-    let titleText: string =
-      props.label +
-      ' for ' +
-      placesStore.latLng?.lat +
-      ', ' +
-      placesStore.latLng?.lng
+    let titleText: string = chartStore.getChartTitle(props.label)
 
     if (props.depth) {
       titleText += '<br />Depth: ' + props.depth + ', '
@@ -209,6 +204,11 @@ const buildChart = () => {
           'autoScale2d',
           'resetScale2d',
         ],
+        toImageButtonOptions: {
+          format: 'png',
+          filename: titleText,
+          scale: 2,
+        },
       }
     )
   }

--- a/explorer/components/TasPrChart.vue
+++ b/explorer/components/TasPrChart.vue
@@ -24,6 +24,7 @@ const { $Plotly } = useNuxtApp()
 const store = useStore()
 const dataStore = useDataStore()
 const placesStore = usePlacesStore()
+const chartStore = useChartStore()
 
 const seasonInput = defineModel('season', { default: 'DJF' })
 const scenarioInput = defineModel('scenario', { default: 'rcp85' })
@@ -119,11 +120,7 @@ const buildChart = () => {
       {
         title: {
           text:
-            props.label +
-            ' for ' +
-            placesStore.latLng?.lat +
-            ', ' +
-            placesStore.latLng?.lng +
+            chartStore.getChartTitle(props.label) +
             ' (5-Model Average)<br />' +
             'Season: ' +
             seasonLabels[seasonInput.value] +
@@ -161,6 +158,11 @@ const buildChart = () => {
           'autoScale2d',
           'resetScale2d',
         ],
+        toImageButtonOptions: {
+          format: 'png',
+          filename: chartStore.getChartTitle(props.label),
+          scale: 2,
+        },
       }
     )
   }

--- a/explorer/components/TasPrChart.vue
+++ b/explorer/components/TasPrChart.vue
@@ -114,57 +114,28 @@ const buildChart = () => {
       },
     })
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text:
-            chartStore.getChartTitle(props.label) +
-            ' (5-Model Average)<br />' +
-            'Season: ' +
-            seasonLabels[seasonInput.value] +
-            ', Scenario: ' +
-            scenarioLabels[scenarioInput.value],
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          tickvals: yearRanges,
-          ticktext: yearRangesWithDashes,
-          dtick: 1,
-        },
-        yaxis: {
-          title: {
-            text: props.label + ' (' + props.units + ')',
-            font: {
-              size: 18,
-            },
-          },
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-        toImageButtonOptions: {
-          format: 'png',
-          filename: chartStore.getChartTitle(props.label),
-          scale: 2,
-        },
-      }
-    )
+    const chartTitle = chartStore.getChartTitle(props.label)
+
+    const titleText =
+      chartTitle +
+      ' (5-Model Average)<br />' +
+      'Season: ' +
+      seasonLabels[seasonInput.value] +
+      ', Scenario: ' +
+      scenarioLabels[scenarioInput.value]
+
+    const yAxisLabel = props.label + ' (' + props.units + ')'
+
+    const xAxis = {
+      tickvals: yearRanges,
+      ticktext: yearRangesWithDashes,
+      dtick: 1,
+    }
+
+    const layout = getLayout(titleText, yAxisLabel, xAxis)
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/components/global/AlfrescoFlammability.vue
+++ b/explorer/components/global/AlfrescoFlammability.vue
@@ -73,49 +73,21 @@ const buildChart = () => {
       },
     })
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text:
-            'Flammability for ' +
-            'HUC-12 ' +
-            apiData.value['huc_id'] +
-            '<br />' +
-            'Model: ' +
-            modelInput.value +
-            ', Scenario: ' +
-            scenarioLabels[scenarioInput.value],
-          font: {
-            size: 24,
-          },
-        },
-        yaxis: {
-          title: {
-            text: 'Flammability (%)',
-            font: {
-              size: 18,
-            },
-          },
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-      }
-    )
+    const chartTitle = 'Flammability for HUC-12 ' + apiData.value['huc_id']
+    const titleText =
+      chartTitle +
+      '<br />' +
+      'Model: ' +
+      modelInput.value +
+      ', Scenario: ' +
+      scenarioLabels[scenarioInput.value]
+
+    const yAxisLabel = 'Flammability (%)'
+
+    const layout = getLayout(titleText, yAxisLabel)
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/components/global/AlfrescoVegetation.vue
+++ b/explorer/components/global/AlfrescoVegetation.vue
@@ -86,50 +86,23 @@ const buildChart = () => {
       })
     })
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text:
-            'Vegetation type for ' +
-            'HUC-12 ' +
-            apiData.value['huc_id'] +
-            '<br />' +
-            'Model: ' +
-            modelInput.value +
-            ', Scenario: ' +
-            scenarioLabels[scenarioInput.value],
-          font: {
-            size: 24,
-          },
-        },
-        yaxis: {
-          title: {
-            text: 'Vegetation type coverage (%)',
-            font: {
-              size: 18,
-            },
-          },
-        },
-        barmode: 'stack',
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-      }
-    )
+    const chartTitle = 'Vegetation type for HUC-12 ' + apiData.value['huc_id']
+    const titleText =
+      chartTitle +
+      '<br />' +
+      'Model: ' +
+      modelInput.value +
+      ', Scenario: ' +
+      scenarioLabels[scenarioInput.value]
+
+    const yAxisLabel = 'Vegetation type coverage (%)'
+
+    const layout = getLayout(titleText, yAxisLabel)
+    layout.barmode = 'stack'
+
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/components/global/LandfastSeaIce.vue
+++ b/explorer/components/global/LandfastSeaIce.vue
@@ -4,6 +4,7 @@ const endpoint = 'landfastSeaIce'
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
+const chartStore = useChartStore()
 const runtimeConfig = useRuntimeConfig()
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -232,52 +233,30 @@ const buildChart = () => {
     } satisfies Data,
   ]
 
-  $Plotly.newPlot(
-    'chart',
-    plotData,
-    {
-      title: {
-        text:
-          'Landfast sea ice for ' +
-          latLng.value?.lat +
-          ', ' +
-          latLng.value?.lng +
-          '<br />' +
-          'Year: ' +
-          yearInput.value,
-        font: {
-          size: 24,
-        },
-      },
-      xaxis: {
-        title: {
-          text: 'Day of the month',
-          font: {
-            size: 18,
-          },
-        },
-        showgrid: false,
-      },
-      yaxis: {
-        showgrid: false,
+  const chartTitle = chartStore.getChartTitle('Landfast Sea Ice Extent')
+
+  const titleText = chartTitle + '<br />' + 'Year: ' + yearInput.value
+
+  const yAxisLabel = 'Month'
+
+  const xAxis = {
+    title: {
+      text: 'Day of the month',
+      font: {
+        size: 18,
       },
     },
-    {
-      responsive: true, // changes the height / width dynamically for charts
-      displayModeBar: true, // always show the camera icon
-      displaylogo: false,
-      modeBarButtonsToRemove: [
-        'zoom2d',
-        'pan2d',
-        'select2d',
-        'lasso2d',
-        'zoomIn2d',
-        'zoomOut2d',
-        'autoScale2d',
-        'resetScale2d',
-      ],
-    }
-  )
+    showgrid: false,
+  }
+
+  const layout = getLayout(titleText, yAxisLabel, xAxis)
+  layout.yaxis = {
+    showgrid: false,
+  }
+
+  const config = getConfig(chartTitle)
+
+  $Plotly.newPlot('chart', plotData, layout, config)
 }
 
 watch(latLng, async () => {

--- a/explorer/components/global/PrecipitationFrequency.vue
+++ b/explorer/components/global/PrecipitationFrequency.vue
@@ -7,6 +7,7 @@ const { $Plotly, $_ } = useNuxtApp()
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
+const chartStore = useChartStore()
 const runtimeConfig = useRuntimeConfig()
 
 const durationInput = defineModel('duration', { default: '24h' })
@@ -105,55 +106,24 @@ const buildChart = () => {
       })
     })
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text:
-            'Precipitation frequency for ' +
-            latLng.value?.lat +
-            ', ' +
-            latLng.value?.lng +
-            '<br />' +
-            'Duration: ' +
-            durationInput.value +
-            ', Return interval: ' +
-            returnIntervalInput.value,
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          tickvals: ticks,
-          ticktext: ['', ...eras],
-          dtick: 1,
-        },
-        yaxis: {
-          title: {
-            text: 'Precipitation (㎜)',
-            font: {
-              size: 18,
-            },
-          },
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-      }
-    )
+    const chartTitle = chartStore.getChartTitle('Precipitation Frequency')
+
+    const titleText =
+      chartTitle +
+      '<br />' +
+      'Duration: ' +
+      durationInput.value +
+      ', Return interval: ' +
+      returnIntervalInput.value
+
+    const yAxisLabel = 'Precipitation (㎜)'
+
+    const xAxis = { tickvals: ticks, ticktext: ['', ...eras], dtick: 1 }
+
+    const layout = getLayout(titleText, yAxisLabel, xAxis)
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/components/global/SeaIceConcentration.vue
+++ b/explorer/components/global/SeaIceConcentration.vue
@@ -4,6 +4,7 @@ const endpoint = 'seaIceConcentration'
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
+const chartStore = useChartStore()
 const runtimeConfig = useRuntimeConfig()
 
 const { $Plotly, $_ } = useNuxtApp()
@@ -131,52 +132,31 @@ const buildChart = () => {
       },
     })
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text:
-            'Sea ice concentration for ' +
-            latLng.value?.lat +
-            ', ' +
-            latLng.value?.lng +
-            '<br />' +
-            'Month: ' +
-            months[parseInt(monthInput.value) - 1],
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          title: {
-            text: 'Year',
-            font: {
-              size: 18,
-            },
-          },
-          showgrid: false,
-        },
-        yaxis: {
-          showgrid: false,
+    const chartTitle = chartStore.getChartTitle('Sea Ice Concentration')
+
+    const titleText =
+      chartTitle + '<br />' + 'Month: ' + months[parseInt(monthInput.value) - 1]
+
+    const yAxisLabel = 'Sea Ice Concentration (%)'
+
+    const xAxis = {
+      title: {
+        text: 'Year',
+        font: {
+          size: 18,
         },
       },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-      }
-    )
+      showgrid: false,
+    }
+
+    const layout = getLayout(titleText, yAxisLabel, xAxis)
+    layout.yaxis = {
+      showgrid: false,
+    }
+
+    const config = getConfig(chartTitle)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/components/global/WetDaysPerYear.vue
+++ b/explorer/components/global/WetDaysPerYear.vue
@@ -10,6 +10,7 @@ const { $Plotly, $_ } = useNuxtApp()
 const placesStore = usePlacesStore()
 const mapStore = useMapStore()
 const dataStore = useDataStore()
+const chartStore = useChartStore()
 const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
@@ -207,51 +208,20 @@ const buildChart = () => {
       })
     })
 
-    $Plotly.newPlot(
-      'chart',
-      traces,
-      {
-        title: {
-          text:
-            'Wet days per year for ' +
-            latLng.value?.lat +
-            ', ' +
-            latLng.value?.lng,
-          font: {
-            size: 24,
-          },
-        },
-        xaxis: {
-          // Pad x-axis with one null to avoid overlapping y-axis line.
-          tickvals: [null].concat($_.range(1, allDecades.length)),
-          ticktext: allDecades,
-          dtick: 1,
-        },
-        yaxis: {
-          title: {
-            text: 'Wet days per year',
-            font: {
-              size: 18,
-            },
-          },
-        },
-      },
-      {
-        responsive: true, // changes the height / width dynamically for charts
-        displayModeBar: true, // always show the camera icon
-        displaylogo: false,
-        modeBarButtonsToRemove: [
-          'zoom2d',
-          'pan2d',
-          'select2d',
-          'lasso2d',
-          'zoomIn2d',
-          'zoomOut2d',
-          'autoScale2d',
-          'resetScale2d',
-        ],
-      }
-    )
+    const titleText = chartStore.getChartTitle('Wet Days Per Year')
+
+    const yAxisLabel = 'Wet days per year'
+    const xAxis = {
+      // Pad x-axis with one null to avoid overlapping y-axis line.
+      tickvals: [null].concat($_.range(1, allDecades.length)),
+      ticktext: allDecades,
+      dtick: 1,
+    }
+
+    const layout = getLayout(titleText, yAxisLabel, xAxis)
+    const config = getConfig(titleText)
+
+    $Plotly.newPlot('chart', traces, layout, config)
   }
 }
 

--- a/explorer/stores/chart.ts
+++ b/explorer/stores/chart.ts
@@ -18,8 +18,21 @@ export const useChartStore = defineStore('chart', () => {
     >
   > = ref({})
 
+function getChartTitle(label: string): string {
+    const placesStore = usePlacesStore()
+    let title = label + ' for '
+    if (placesStore.selectedCommunity) {
+      title += placesStore.selectedCommunity.name + ' at '
+    }
+    if (placesStore.latLng) {
+      title += placesStore.latLng.lat + ', ' + placesStore.latLng.lng
+    }
+    return title
+  }
+
   return {
     labels,
     inputs,
+    getChartTitle,
   }
 })

--- a/explorer/utils/chart.ts
+++ b/explorer/utils/chart.ts
@@ -1,0 +1,46 @@
+import type { Config, Layout } from 'plotly.js-dist-min'
+
+export const getConfig = (filename: string): Partial<Config> => ({
+  responsive: true, // changes the height / width dynamically for charts
+  displayModeBar: true, // always show the camera icon
+  displaylogo: false,
+  modeBarButtonsToRemove: [
+    'zoom2d',
+    'pan2d',
+    'select2d',
+    'lasso2d',
+    'zoomIn2d',
+    'zoomOut2d',
+    'autoScale2d',
+    'resetScale2d',
+  ],
+  toImageButtonOptions: {
+    format: 'png',
+    filename: filename,
+    scale: 2,
+  },
+})
+
+export const getLayout = (
+  title: string,
+  yAxisLabel: string,
+  xAxisConfig?: Partial<Layout['xaxis']>
+): Partial<Layout> => ({
+  title: {
+    text: title,
+    font: {
+      size: 24,
+    },
+  },
+  xaxis: {
+    ...xAxisConfig,
+  },
+  yaxis: {
+    title: {
+      text: yAxisLabel,
+      font: {
+        size: 18,
+      },
+    },
+  },
+})


### PR DESCRIPTION
This PR updates the charts throughout ARDAC to add the community name (if a community is chosen) to the chart title and the snapshot icon's filename. In addition, the boilerplate Plotly layout and configuration have been moved into a set of utility functions that have default settings for the charts in ARDAC. 

This change should have affected all charts in the X-ray items and you should expect that the same chart's data is shown between this update and the live site.

This represents half of the work required for #85 to be closed.