### PR TITLE
Adds DownloadLinks component and changes download link title if community is selected

### DIFF
--- a/explorer/components/DownloadLinks.vue
+++ b/explorer/components/DownloadLinks.vue
@@ -1,0 +1,67 @@
+<script lang="ts" setup>
+interface Props {
+  endpoint: string
+  variables?: string
+}
+
+const props = defineProps<Props>()
+
+const placesStore = usePlacesStore()
+const runtimeConfig = useRuntimeConfig()
+
+const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
+
+const baseUrl = computed(() => {
+  if (!latLng.value) return ''
+  return (
+    runtimeConfig.public.apiUrl +
+    props.endpoint +
+    '/' +
+    latLng.value.lat +
+    '/' +
+    latLng.value.lng
+  )
+})
+
+const jsonUrl = computed(() => {
+  if (!baseUrl.value) return ''
+  let url = baseUrl.value
+
+  // Used by CMIP6 to specify multiple variables.
+  if (props.variables) {
+    url += '?vars=' + props.variables
+  }
+
+  return url
+})
+
+const csvUrl = computed(() => {
+  if (!jsonUrl.value) return ''
+  let url = jsonUrl.value
+
+  if (selectedCommunity.value) {
+    url +=
+      (url.includes('?') ? '&' : '?') +
+      'community=' +
+      selectedCommunity.value.id
+  }
+
+  url += (url.includes('?') ? '&' : '?') + 'format=csv'
+
+  return url
+})
+</script>
+
+<template>
+  <ul>
+    <li>
+      <a :href="csvUrl">Download as CSV</a>
+    </li>
+    <li>
+      <a :href="jsonUrl">Download as JSON</a>
+    </li>
+  </ul>
+</template>

--- a/explorer/components/global/AlfrescoFlammability.vue
+++ b/explorer/components/global/AlfrescoFlammability.vue
@@ -277,33 +277,7 @@ onUnmounted(() => {
           example, a flammability value of 0.002 is equivalent to 0.2%
           flammability.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/alfresco/flammability/local/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/alfresco/flammability/local/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/alfresco/flammability/local" />
       </div>
       <GetAndUseDataAlfresco
         :presentInNcr="true"

--- a/explorer/components/global/AlfrescoVegetation.vue
+++ b/explorer/components/global/AlfrescoVegetation.vue
@@ -277,33 +277,7 @@ onUnmounted(() => {
           enclosing {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/alfresco/veg_type/local/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/alfresco/veg_type/local/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/alfresco/veg_type/local" />
       </div>
       <GetAndUseDataAlfresco
         :presentInNcr="true"

--- a/explorer/components/global/ClimateBeetleProtection.vue
+++ b/explorer/components/global/ClimateBeetleProtection.vue
@@ -220,33 +220,7 @@ onUnmounted(() => {
           {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/beetles/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/beetles/point/' +
-                latLng!.lat +
-                '/' +
-                latLng!.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/beetles/point" />
       </div>
       <GetAndUseDataBeetle />
     </div>

--- a/explorer/components/global/ClimateBeetleProtection.vue
+++ b/explorer/components/global/ClimateBeetleProtection.vue
@@ -11,6 +11,9 @@ const scenarioInput = defineModel('scenario', { default: 'rcp85' })
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const eras = ['2010-2039', '2040-2069', '2070-2099']
 const models = ['NCAR-CCSM4', 'GFDL-ESM2M', 'HadGEM2-ES', 'MRI-CGCM3']
@@ -165,8 +168,9 @@ onUnmounted(() => {
           </div>
         </div>
         <h4 class="title is-4">
-          Climate protection from spruce beetles for {{ latLng.lat }},
-          {{ latLng.lng }} with
+          Climate protection from spruce beetles for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }}, {{ latLng.lng }} with
           {{ snowpackLabels[snowpackInput].toLowerCase() }} snowpack
         </h4>
         <table class="mb-6">
@@ -217,6 +221,7 @@ onUnmounted(() => {
         </table>
         <h4 class="title is-4">
           Download climate protection from spruce beetles data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
           {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>

--- a/explorer/components/global/DdBelow0.vue
+++ b/explorer/components/global/DdBelow0.vue
@@ -98,33 +98,7 @@ mapStore.setLegendItems(mapId, legend)
           Download degree days below 0&deg;F data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/degree_days/below_zero/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/degree_days/below_zero/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/degree_days/below_zero" />
       </div>
       <GetAndUseDataDegreeDays />
     </div>

--- a/explorer/components/global/DdBelow0.vue
+++ b/explorer/components/global/DdBelow0.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -95,7 +98,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download degree days below 0&deg;F data for {{ latLng.lat }},
+          Download degree days below 0&deg;F data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : ''
+          }}{{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/degree_days/below_zero" />

--- a/explorer/components/global/DdBelow65.vue
+++ b/explorer/components/global/DdBelow65.vue
@@ -100,33 +100,7 @@ mapStore.setLegendItems(mapId, legend)
           Download degree days below 65&deg;F data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/degree_days/heating/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/degree_days/heating/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/degree_days/heating" />
       </div>
       <GetAndUseDataDegreeDays :presentInEds="true" />
     </div>

--- a/explorer/components/global/DdBelow65.vue
+++ b/explorer/components/global/DdBelow65.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -97,7 +100,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download degree days below 65&deg;F data for {{ latLng.lat }},
+          Download degree days below 65&deg;F data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : ''
+          }}{{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/degree_days/heating" />

--- a/explorer/components/global/EvaporationCmip6.vue
+++ b/explorer/components/global/EvaporationCmip6.vue
@@ -211,34 +211,7 @@ onUnmounted(() => {
           Download CMIP6 evaporation data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=evspsbl&format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=evspsbl'
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/cmip6/point" variables="evspsbl" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/EvaporationCmip6.vue
+++ b/explorer/components/global/EvaporationCmip6.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -208,7 +211,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download CMIP6 evaporation data for {{ latLng.lat }},
+          Download CMIP6 evaporation data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/cmip6/point" variables="evspsbl" />

--- a/explorer/components/global/FreezingIndex.vue
+++ b/explorer/components/global/FreezingIndex.vue
@@ -52,7 +52,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section">
     <div class="content is-size-5">
       <h3 class="title is-3">Freezing Index</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The freezing index is the number of degree days above freezing per year.
         The map below shows the 30-year mean of the freezing index for three
@@ -95,33 +95,7 @@ mapStore.setLegendItems(mapId, legend)
           Download freezing index data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/degree_days/freezing_index/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/degree_days/freezing_index/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/degree_days/freezing_index" />
       </div>
       <GetAndUseDataDegreeDays :presentInEds="true">
         <li>

--- a/explorer/components/global/FreezingIndex.vue
+++ b/explorer/components/global/FreezingIndex.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -92,7 +95,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download freezing index data for {{ latLng.lat }},
+          Download freezing index data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/degree_days/freezing_index" />

--- a/explorer/components/global/HydrologyEvap.vue
+++ b/explorer/components/global/HydrologyEvap.vue
@@ -101,33 +101,7 @@ onUnmounted(() => {
           The following download links bundle evapotranspiration data with other
           hydrology data. Evapotranspiration uses the "evap" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/hydrology/point" />
       </div>
       <GetAndUseDataHydrology :presentInNcr="true" />
     </div>

--- a/explorer/components/global/HydrologyEvap.vue
+++ b/explorer/components/global/HydrologyEvap.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -94,7 +97,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download evapotranspiration data for {{ latLng.lat }},
+          Download evapotranspiration data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/HydrologyGlacierMelt.vue
+++ b/explorer/components/global/HydrologyGlacierMelt.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -94,7 +97,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download glacier melt data for {{ latLng.lat }},
+          Download glacier melt data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/HydrologyGlacierMelt.vue
+++ b/explorer/components/global/HydrologyGlacierMelt.vue
@@ -101,33 +101,7 @@ onUnmounted(() => {
           The following download links bundle glacier melt data with other
           hydrology data. Glacier melt uses the "glacier_melt" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/hydrology/point" />
       </div>
       <GetAndUseDataHydrology />
     </div>

--- a/explorer/components/global/HydrologyIswe.vue
+++ b/explorer/components/global/HydrologyIswe.vue
@@ -153,33 +153,7 @@ onUnmounted(() => {
           with other hydrology data. Ice water equivalent uses the "iwe"
           identifier and snow water equivalent uses the "swe" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/hydrology/point" />
       </div>
       <GetAndUseDataHydrology />
     </div>

--- a/explorer/components/global/HydrologyIswe.vue
+++ b/explorer/components/global/HydrologyIswe.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -145,7 +148,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download ice/snow water equivalent data for {{ latLng.lat }},
+          Download ice/snow water equivalent data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/HydrologyRunoff.vue
+++ b/explorer/components/global/HydrologyRunoff.vue
@@ -101,33 +101,7 @@ onUnmounted(() => {
           The following download links bundle runoff data with other hydrology
           data. Runoff uses the "runoff" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/hydrology/point" />
       </div>
       <GetAndUseDataHydrology :presentInNcr="true" />
     </div>

--- a/explorer/components/global/HydrologyRunoff.vue
+++ b/explorer/components/global/HydrologyRunoff.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -94,7 +97,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download runoff data for {{ latLng.lat }},
+          Download runoff data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/HydrologySm.vue
+++ b/explorer/components/global/HydrologySm.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -198,7 +201,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download soil moisture data for {{ latLng.lat }},
+          Download soil moisture data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/HydrologySm.vue
+++ b/explorer/components/global/HydrologySm.vue
@@ -206,33 +206,7 @@ onUnmounted(() => {
           hydrology data. Soil moisture uses the "sm1" (layer 1), "sm2" (layer
           2), and "sm3" (layer 3) identifiers.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/hydrology/point" />
       </div>
       <GetAndUseDataHydrology />
     </div>

--- a/explorer/components/global/HydrologySnowMelt.vue
+++ b/explorer/components/global/HydrologySnowMelt.vue
@@ -101,33 +101,7 @@ onUnmounted(() => {
           The following download links bundle snow melt data with other
           hydrology data. Snow melt uses the "snow_melt" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/hydrology/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/hydrology/point" />
       </div>
       <GetAndUseDataHydrology />
     </div>

--- a/explorer/components/global/HydrologySnowMelt.vue
+++ b/explorer/components/global/HydrologySnowMelt.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -94,7 +97,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download snow melt data for {{ latLng.lat }},
+          Download snow melt data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorCd.vue
+++ b/explorer/components/global/IndicatorCd.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -113,7 +116,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download cold day threshold data for {{ latLng.lat }},
+          Download cold day threshold data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorCd.vue
+++ b/explorer/components/global/IndicatorCd.vue
@@ -120,33 +120,7 @@ mapStore.setLegendItems(mapId, legend)
           The following download links bundle cold day threshold data with other
           climate indicators. Cold day threshold uses the "cd" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorCdd.vue
+++ b/explorer/components/global/IndicatorCdd.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -113,7 +116,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download consecutive dry days data for {{ latLng.lat }},
+          Download consecutive dry days data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorCdd.vue
+++ b/explorer/components/global/IndicatorCdd.vue
@@ -70,7 +70,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Consecutive Dry Days</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         Consecutive dry days are the number of the most consecutive days with at
         least 1㎜ precipitation. The map below shows the 30-year mean of
@@ -121,33 +121,7 @@ mapStore.setLegendItems(mapId, legend)
           other climate indicators. Consecutive dry days uses the "cdd"
           identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorCsdi.vue
+++ b/explorer/components/global/IndicatorCsdi.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -118,7 +121,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download cold spell duration index data for {{ latLng.lat }},
+          Download cold spell duration index data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorCsdi.vue
+++ b/explorer/components/global/IndicatorCsdi.vue
@@ -70,7 +70,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Cold Spell Duration Index</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The cold spell duration index is the annual count of occurrences of at
         least 5 consecutive days with daily mean 2m air temperature above 90th
@@ -126,33 +126,7 @@ mapStore.setLegendItems(mapId, legend)
           with other climate indicators. Cold spell duration index uses the
           "csdi" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorCwd.vue
+++ b/explorer/components/global/IndicatorCwd.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -113,7 +116,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download consecutive wet days data for {{ latLng.lat }},
+          Download consecutive wet days data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorCwd.vue
+++ b/explorer/components/global/IndicatorCwd.vue
@@ -70,7 +70,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Consecutive Wet Days</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         Consecutive wet days are the number of the most consecutive days with at
         least 1㎜ precipitation. The map below shows the 30-year mean of
@@ -121,33 +121,7 @@ mapStore.setLegendItems(mapId, legend)
           other climate indicators. Consecutive wet days uses the "cwd"
           identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorDw.vue
+++ b/explorer/components/global/IndicatorDw.vue
@@ -70,7 +70,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Deep Winter Days</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         Deep winter days are the number of days per year that are below
         -22&deg;F. The map below shows the 30-year mean of deep winter days for
@@ -118,33 +118,7 @@ mapStore.setLegendItems(mapId, legend)
           The following download links bundle summer days data with other
           climate indicators. Deep winter days use the "dw" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorDw.vue
+++ b/explorer/components/global/IndicatorDw.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -112,7 +115,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download deep winter days data for {{ latLng.lat }}, {{ latLng.lng }}
+          Download deep winter days data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }}, {{ latLng.lng }}
         </h4>
         <p>
           The following download links bundle summer days data with other

--- a/explorer/components/global/IndicatorDwCmip6.vue
+++ b/explorer/components/global/IndicatorDwCmip6.vue
@@ -104,33 +104,7 @@ mapStore.setLegendItems(mapId, legend)
           The following download links bundle deep winter days data with other
           climate indicators. Deep winter days use the "dw" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/cmip6/point" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/IndicatorDwCmip6.vue
+++ b/explorer/components/global/IndicatorDwCmip6.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -97,7 +100,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download deep winter days data for {{ latLng.lat }},
+          Download deep winter days data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorFtcCmip6.vue
+++ b/explorer/components/global/IndicatorFtcCmip6.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -102,7 +105,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download freeze/thaw cycle data for {{ latLng.lat }},
+          Download freeze/thaw cycle data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorFtcCmip6.vue
+++ b/explorer/components/global/IndicatorFtcCmip6.vue
@@ -109,33 +109,7 @@ mapStore.setLegendItems(mapId, legend)
           The following download links bundle freeze/thaw cycle data with other
           climate indicators. Freeze/thaw cycle uses the "ftc" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/cmip6/point" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/IndicatorHd.vue
+++ b/explorer/components/global/IndicatorHd.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -113,7 +116,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download hot day threshold data for {{ latLng.lat }},
+          Download hot day threshold data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorHd.vue
+++ b/explorer/components/global/IndicatorHd.vue
@@ -120,33 +120,7 @@ mapStore.setLegendItems(mapId, legend)
           The following download links bundle hot day threshold data with other
           climate indicators. Hot day threshold uses the "hd" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorR10mm.vue
+++ b/explorer/components/global/IndicatorR10mm.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -113,7 +116,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download heavy precipitation days data for {{ latLng.lat }},
+          Download heavy precipitation days data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorR10mm.vue
+++ b/explorer/components/global/IndicatorR10mm.vue
@@ -70,7 +70,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Heavy Precipitation Days</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         Heavy precipitation days are the number of days in a year with at least
         10㎜ precipitation. The map below shows the 30-year mean of heavy
@@ -121,33 +121,7 @@ mapStore.setLegendItems(mapId, legend)
           other climate indicators. Heavy precipitation days uses the "r10mm"
           identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorRx1day.vue
+++ b/explorer/components/global/IndicatorRx1day.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -116,7 +119,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download maximum 1-day precipitation data for {{ latLng.lat }},
+          Download maximum 1-day precipitation data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorRx1day.vue
+++ b/explorer/components/global/IndicatorRx1day.vue
@@ -70,7 +70,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Maximum 1-day Precipitation</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean of the maximum 1-day precipitation
         for three eras. The historical era (1980&ndash;2009) uses historical
@@ -124,33 +124,7 @@ mapStore.setLegendItems(mapId, legend)
           with other climate indicators. Maximum 1-day precipitation uses the
           "rx1day" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorRx1dayCmip6.vue
+++ b/explorer/components/global/IndicatorRx1dayCmip6.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -101,7 +104,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download maximum 1-day precipitation data for {{ latLng.lat }},
+          Download maximum 1-day precipitation data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorRx1dayCmip6.vue
+++ b/explorer/components/global/IndicatorRx1dayCmip6.vue
@@ -109,33 +109,7 @@ mapStore.setLegendItems(mapId, legend)
           with other climate indicators. Maximum 1-day precipitation uses the
           "rx1day" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/cmip6/point" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/IndicatorRx5day.vue
+++ b/explorer/components/global/IndicatorRx5day.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -116,7 +119,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download maximum 5-day precipitation data for {{ latLng.lat }},
+          Download maximum 5-day precipitation data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorRx5day.vue
+++ b/explorer/components/global/IndicatorRx5day.vue
@@ -70,7 +70,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Maximum 5-day Precipitation</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The map below shows the 30-year mean of the maximum 5-day precipitation
         for three eras. The historical era (1980&ndash;2009) uses historical
@@ -124,33 +124,7 @@ mapStore.setLegendItems(mapId, legend)
           with other climate indicators. Maximum 5-day precipitation uses the
           "rx5day" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorSu.vue
+++ b/explorer/components/global/IndicatorSu.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -112,7 +115,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download summer days data for {{ latLng.lat }}, {{ latLng.lng }}
+          Download summer days data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }}, {{ latLng.lng }}
         </h4>
         <p>
           The following download links bundle summer days data with other

--- a/explorer/components/global/IndicatorSu.vue
+++ b/explorer/components/global/IndicatorSu.vue
@@ -70,7 +70,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Summer Days</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         Summer days are the number of days per year that are above 77&deg;F. The
         map below shows the 30-year mean of summer days for three eras. The
@@ -118,33 +118,7 @@ mapStore.setLegendItems(mapId, legend)
           The following download links bundle summer days data with other
           climate indicators. Summer days use the "su" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/IndicatorSuCmip6.vue
+++ b/explorer/components/global/IndicatorSuCmip6.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -96,7 +99,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download CMIP6 summer days data for {{ latLng.lat }},
+          Download CMIP6 summer days data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorSuCmip6.vue
+++ b/explorer/components/global/IndicatorSuCmip6.vue
@@ -103,33 +103,7 @@ mapStore.setLegendItems(mapId, legend)
           The following download links bundle summer days data with other CMIP6
           climate indicators. Summer days use the "su" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/cmip6/point" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/IndicatorWsdi.vue
+++ b/explorer/components/global/IndicatorWsdi.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -118,7 +121,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download warm spell duration index data for {{ latLng.lat }},
+          Download warm spell duration index data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/IndicatorWsdi.vue
+++ b/explorer/components/global/IndicatorWsdi.vue
@@ -69,7 +69,7 @@ mapStore.setLegendItems(mapId, legend)
 <template>
   <section class="section xray">
     <div class="content is-size-5">
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <h3 class="title is-3">Warm Spell Duration Index</h3>
       <p class="mb-6">
         The warm spell duration index is the annual count of occurrences of at
@@ -126,33 +126,7 @@ mapStore.setLegendItems(mapId, legend)
           with other climate indicators. Warm spell duration index uses the
           "wsdi" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/indicators/base/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/indicators/base/point" />
       </div>
       <GetAndUseDataIndicators :presentInNcr="true" />
     </div>

--- a/explorer/components/global/LandfastSeaIce.vue
+++ b/explorer/components/global/LandfastSeaIce.vue
@@ -13,6 +13,9 @@ const yearInput = defineModel('snowpack', { default: '2023' })
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const years = $_.range(1996, 2024)
 
@@ -415,7 +418,9 @@ onUnmounted(() => {
           </div>
         </div>
         <h4 class="title is-4">
-          Download landfast sea ice data for {{ latLng.lat }},
+          Download landfast sea ice data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/landfastice/point" />

--- a/explorer/components/global/LandfastSeaIce.vue
+++ b/explorer/components/global/LandfastSeaIce.vue
@@ -418,33 +418,7 @@ onUnmounted(() => {
           Download landfast sea ice data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/landfastice/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/landfastice/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/landfastice/point" />
       </div>
       <GetAndUseData apiUrl="https://earthmaps.io/landfastice/" />
       <Bios :people="['Andy Mahoney', 'Hajo Eicken']" />

--- a/explorer/components/global/OceanographyCmip6.vue
+++ b/explorer/components/global/OceanographyCmip6.vue
@@ -157,34 +157,7 @@ onUnmounted(() => {
           {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=psl,ts&format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=psl,ts'
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/cmip6/point" variables="psl,ts" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/OceanographyCmip6.vue
+++ b/explorer/components/global/OceanographyCmip6.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -154,6 +157,7 @@ onUnmounted(() => {
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
           Download CMIP6 sea level pressure and surface temperature data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
           {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>

--- a/explorer/components/global/PermafrostBaseTop.vue
+++ b/explorer/components/global/PermafrostBaseTop.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -157,7 +160,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download permafrost base and top depth data for {{ latLng.lat }},
+          Download permafrost base and top depth data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/PermafrostBaseTop.vue
+++ b/explorer/components/global/PermafrostBaseTop.vue
@@ -166,33 +166,7 @@ onUnmounted(() => {
           "permafrostbase" identifier. Permafrost top depth uses the
           "permafrosttop" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/permafrost/point/gipl/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/permafrost/point/gipl/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/permafrost/point/gipl" />
       </div>
       <GetAndUseDataPermafrost :presentInNcr="true" :presentInEds="true" />
     </div>

--- a/explorer/components/global/PermafrostMagt.vue
+++ b/explorer/components/global/PermafrostMagt.vue
@@ -158,33 +158,7 @@ onUnmounted(() => {
           data with other permafrost data. Mean annual ground temperature uses
           the "magt" identifier prefix.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/permafrost/point/gipl/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/permafrost/point/gipl/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/permafrost/point/gipl" />
       </div>
       <GetAndUseDataPermafrost :presentInNcr="true" :presentInEds="true" />
     </div>

--- a/explorer/components/global/PermafrostMagt.vue
+++ b/explorer/components/global/PermafrostMagt.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -150,7 +153,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download mean annual ground temperature data for {{ latLng.lat }},
+          Download mean annual ground temperature data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/PermafrostTalik.vue
+++ b/explorer/components/global/PermafrostTalik.vue
@@ -105,33 +105,7 @@ onUnmounted(() => {
           The following download links bundle talik thickness data with other
           permafrost data. Talik thickness uses the "talikthickness" identifier.
         </p>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/permafrost/point/gipl/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/permafrost/point/gipl/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/permafrost/point/gipl" />
       </div>
       <GetAndUseDataPermafrost />
     </div>

--- a/explorer/components/global/PermafrostTalik.vue
+++ b/explorer/components/global/PermafrostTalik.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -98,7 +101,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download talik thickness data for {{ latLng.lat }},
+          Download talik thickness data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <p>

--- a/explorer/components/global/PrecipitationCmip6.vue
+++ b/explorer/components/global/PrecipitationCmip6.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -168,7 +171,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download CMIP6 precipitation data for {{ latLng.lat }},
+          Download CMIP6 precipitation data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/cmip6/point" variables="pr" />

--- a/explorer/components/global/PrecipitationCmip6.vue
+++ b/explorer/components/global/PrecipitationCmip6.vue
@@ -171,34 +171,7 @@ onUnmounted(() => {
           Download CMIP6 precipitation data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=pr&format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=pr'
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/cmip6/point" variables="pr" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/PrecipitationFrequency.vue
+++ b/explorer/components/global/PrecipitationFrequency.vue
@@ -15,6 +15,9 @@ const returnIntervalInput = defineModel('returnInterval', { default: '100' })
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const dataError = computed<boolean>(() => dataStore.dataErrors[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 const errorMsg = ref('')
 
 const returnIntervals = [2, 5, 10, 25, 50, 100, 200, 500, 1000]
@@ -331,7 +334,9 @@ onUnmounted(() => {
       <div id="chart"></div>
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download precipitation frequency data for {{ latLng.lat }},
+          Download precipitation frequency data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/precipitation/frequency/point" />

--- a/explorer/components/global/PrecipitationFrequency.vue
+++ b/explorer/components/global/PrecipitationFrequency.vue
@@ -334,33 +334,7 @@ onUnmounted(() => {
           Download precipitation frequency data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/precipitation/frequency/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/precipitation/frequency/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/precipitation/frequency/point" />
       </div>
       <GetAndUseData
         :presentInEds="true"

--- a/explorer/components/global/SeaIceCmip6.vue
+++ b/explorer/components/global/SeaIceCmip6.vue
@@ -178,34 +178,7 @@ mapStore.setLegendItems(mapId, legend)
           Download CMIP6 sea ice concentration data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=siconc&format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=siconc'
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/cmip6/point" variables="siconc" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/SeaIceCmip6.vue
+++ b/explorer/components/global/SeaIceCmip6.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -175,7 +178,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download CMIP6 sea ice concentration data for {{ latLng.lat }},
+          Download CMIP6 sea ice concentration data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/cmip6/point" variables="siconc" />

--- a/explorer/components/global/SeaIceConcentration.vue
+++ b/explorer/components/global/SeaIceConcentration.vue
@@ -263,33 +263,7 @@ onUnmounted(() => {
           Download sea ice concentration data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/seaice/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/seaice/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/seaice/point" />
       </div>
       <GetAndUseData
         apiUrl="https://earthmaps.io/seaice/"

--- a/explorer/components/global/SeaIceConcentration.vue
+++ b/explorer/components/global/SeaIceConcentration.vue
@@ -13,6 +13,9 @@ const monthInput = defineModel({ default: '3' })
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const years = $_.range(1850, 2021)
 
@@ -260,7 +263,9 @@ onUnmounted(() => {
       <div id="chart"></div>
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download sea ice concentration data for {{ latLng.lat }},
+          Download sea ice concentration data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/seaice/point" />

--- a/explorer/components/global/SnowCmip6.vue
+++ b/explorer/components/global/SnowCmip6.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const prsn_layers: MapLayer[] = [
   {
@@ -311,7 +314,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download CMIP6 snow data for {{ latLng.lat }},
+          Download CMIP6 snow data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/cmip6/point" variables="prsn,snw" />

--- a/explorer/components/global/SnowCmip6.vue
+++ b/explorer/components/global/SnowCmip6.vue
@@ -314,34 +314,7 @@ mapStore.setLegendItems(mapId, legend)
           Download CMIP6 snow data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=prsn,snw&format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=prsn,snw'
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/cmip6/point" variables="prsn,snw" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/SolarRadiationCloudCoverCmip6.vue
+++ b/explorer/components/global/SolarRadiationCloudCoverCmip6.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -241,7 +244,9 @@ onUnmounted(() => {
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
           Download CMIP6 downwelling flux, upward heat flux, and cloud area
-          fraction data for {{ latLng.lat }},
+          fraction data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks

--- a/explorer/components/global/SolarRadiationCloudCoverCmip6.vue
+++ b/explorer/components/global/SolarRadiationCloudCoverCmip6.vue
@@ -244,34 +244,10 @@ onUnmounted(() => {
           fraction data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=rsds,rlds,hfss,hfls,clt&format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=rsds,rlds,hfss,hfls,clt'
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks
+          endpoint="/cmip6/point"
+          variables="rsds,rlds,hfss,hfls,clt"
+        />
       </div>
     </div>
   </section>

--- a/explorer/components/global/TemperatureCmip6.vue
+++ b/explorer/components/global/TemperatureCmip6.vue
@@ -203,34 +203,7 @@ onUnmounted(() => {
           Download CMIP6 temperature data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=tas,tasmax,tasmin&format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=tas,tasmax,tasmin'
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/cmip6/point" variables="tas,tasmax,tasmin" />
       </div>
     </div>
   </section>

--- a/explorer/components/global/TemperatureCmip6.vue
+++ b/explorer/components/global/TemperatureCmip6.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -200,7 +203,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download CMIP6 temperature data for {{ latLng.lat }},
+          Download CMIP6 temperature data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/cmip6/point" variables="tas,tasmax,tasmin" />

--- a/explorer/components/global/ThawingIndex.vue
+++ b/explorer/components/global/ThawingIndex.vue
@@ -52,7 +52,7 @@ mapStore.setLegendItems(mapId, legend)
   <section class="section xray">
     <div class="content is-size-5">
       <h3 class="title is-3">Thawing Index</h3>
-      <XrayIntroblurb resolution="~12" unit="km" cmip="5"/>
+      <XrayIntroblurb resolution="~12" unit="km" cmip="5" />
       <p class="mb-6">
         The thawing index is the number of degree days above freezing per year.
         The map below shows the 30-year mean of the thawing index for three
@@ -95,33 +95,7 @@ mapStore.setLegendItems(mapId, legend)
           Download thawing index data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/degree_days/thawing_index/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/degree_days/thawing_index/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/degree_days/thawing_index" />
       </div>
       <GetAndUseDataDegreeDays :presentInEds="true">
         <li>

--- a/explorer/components/global/ThawingIndex.vue
+++ b/explorer/components/global/ThawingIndex.vue
@@ -6,6 +6,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData)
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -92,7 +95,9 @@ mapStore.setLegendItems(mapId, legend)
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download thawing index data for {{ latLng.lat }},
+          Download thawing index data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/degree_days/thawing_index" />

--- a/explorer/components/global/WetDaysPerYear.vue
+++ b/explorer/components/global/WetDaysPerYear.vue
@@ -319,33 +319,7 @@ onUnmounted(() => {
           Download wet days per year data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/wet_days_per_year/all/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/wet_days_per_year/all/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/wet_days_per_year/all/point" />
       </div>
       <GetAndUseData
         apiUrl="https://earthmaps.io/wet_days_per_year/"

--- a/explorer/components/global/WetDaysPerYear.vue
+++ b/explorer/components/global/WetDaysPerYear.vue
@@ -14,6 +14,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -316,7 +319,9 @@ onUnmounted(() => {
       <div id="chart"></div>
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download wet days per year data for {{ latLng.lat }},
+          Download wet days per year data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/wet_days_per_year/all/point" />

--- a/explorer/components/global/WindCmip6.vue
+++ b/explorer/components/global/WindCmip6.vue
@@ -8,6 +8,9 @@ const runtimeConfig = useRuntimeConfig()
 
 const apiData = computed<any[]>(() => dataStore.apiData[endpoint])
 const latLng = computed<LatLngValue>(() => placesStore.latLng)
+const selectedCommunity = computed<CommunityValue>(
+  () => placesStore.selectedCommunity
+)
 
 const layers: MapLayer[] = [
   {
@@ -212,7 +215,9 @@ onUnmounted(() => {
 
       <div v-if="latLng && apiData" class="my-6">
         <h4 class="title is-4">
-          Download CMIP6 near-surface wind speed data for {{ latLng.lat }},
+          Download CMIP6 near-surface wind speed data for
+          {{ selectedCommunity ? selectedCommunity.name + ' at ' : '' }}
+          {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
         <DownloadLinks endpoint="/cmip6/point" variables="sfcWind,uas,vas" />

--- a/explorer/components/global/WindCmip6.vue
+++ b/explorer/components/global/WindCmip6.vue
@@ -215,34 +215,7 @@ onUnmounted(() => {
           Download CMIP6 near-surface wind speed data for {{ latLng.lat }},
           {{ latLng.lng }}
         </h4>
-        <ul>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=sfcWind,uas,vas&format=csv'
-              "
-              >Download as CSV</a
-            >
-          </li>
-          <li>
-            <a
-              :href="
-                runtimeConfig.public.apiUrl +
-                '/cmip6/point/' +
-                latLng.lat +
-                '/' +
-                latLng.lng +
-                '?vars=sfcWind,uas,vas'
-              "
-              >Download as JSON</a
-            >
-          </li>
-        </ul>
+        <DownloadLinks endpoint="/cmip6/point" variables="sfcWind,uas,vas" />
       </div>
     </div>
   </section>


### PR DESCRIPTION
This PR adds a new component called DownloadLinks that replaces the download links section for the CSV and JSON for each of our X-ray items. This is now dynamically generated based on the endpoint provided and whether a community has been selected. If a community is selected, both the download link title and the downloaded CSV filename will change to reflect the community that has been picked.

Along with #187, this closes #85.

**Note**: This does not have the chart title changes that are contained within #187.

Closes #85 