### PR TITLE
Fix "minimum" typo in CMIP6 monthly chart

### DIFF
--- a/explorer/components/global/TemperatureCmip6.vue
+++ b/explorer/components/global/TemperatureCmip6.vue
@@ -192,7 +192,7 @@ onUnmounted(() => {
         class="mb-5"
       />
       <Cmip6MonthlyChart
-        label="Mininum Near-surface Air Temperature"
+        label="Minimum Near-surface Air Temperature"
         units="°C"
         dataKey="tasmin"
         class="mb-5"


### PR DESCRIPTION
Closes #194.

This PR simply fixes a typo. Self-merging because this is a trivial change.