### PR TITLE
Updates mismatched text for Climate Stripes story

### DIFF
--- a/explorer/components/global/StoryClimateStripes1.vue
+++ b/explorer/components/global/StoryClimateStripes1.vue
@@ -113,8 +113,7 @@
       <p>
         The variation of local weather is obvious across these stripes. This
         deep blue line represents 1972, the coldest year in the record with an
-        average annual temperature of just 3.7&deg;C (39&deg;F). The warmest
-        year on record is 2017.
+        average annual temperature of just 3.7&deg;C (39&deg;F).
       </p>
       <p>
         Overall though the trend is clear. Some warmer than average years do


### PR DESCRIPTION
This PR makes a small text change to fix an error that states that the latest year in a graph is 2017. This now states "The warmest year on record is 2017." 

Closes #46 