### PR TITLE
Updates error message for Gimme component to only show 'No matching communities' when the query contains non-numeric characters.

### DIFF
--- a/explorer/components/Gimme.vue
+++ b/explorer/components/Gimme.vue
@@ -23,8 +23,9 @@ const placesStore = usePlacesStore()
 
 const { $autoComplete, $parseDMS } = useNuxtApp()
 
+const STARTS_WITH_LETTER = /^[a-zA-Z]+/
 // Pattern to match characters that are not found in coordinate notation
-const NON_COORDINATE_CHARS_PATTERN = /[^\d\s.,-]/
+const NON_COORDINATE_CHARS_PATTERN = /[^\d\s.,-°'"]/
 
 // Error message constants used in multiple places
 const ERROR_MESSAGES = {
@@ -86,7 +87,10 @@ onMounted(() => {
         if (results.length === 0) {
           // Only show community error message if query contains non-numeric characters.
           // This prevents lat / long inputs from triggering the message.
-          if (NON_COORDINATE_CHARS_PATTERN.test(query)) {
+          if (
+            STARTS_WITH_LETTER.test(query) ||
+            NON_COORDINATE_CHARS_PATTERN.test(query)
+          ) {
             fieldMessage.value = ERROR_MESSAGES.NO_COMMUNITIES_FOUND
           }
         } else {
@@ -168,7 +172,7 @@ const validate = (latLng: string) => {
   let lon: number
 
   // If it's alphanumeric or empty or too short, don't try to parse / validate
-  if (latLng === '' || /^[a-zA-Z]+/.test(latLng) || latLng.length <= 3) {
+  if (latLng === '' || STARTS_WITH_LETTER.test(latLng) || latLng.length <= 3) {
     fieldMessage.value = ''
     latLngIsValid.value = false
     return false


### PR DESCRIPTION
This PR adds a test for the Gimme component that will only show the error message "Sorry, no matching communities" when there are non-numeric characters in the query. If there are only digits, spaces, periods, commas, or minus signs, then the "Sorry, no matching communities" error message will not be shown. Instead, the error message can be one that indicates that the lat / long needs to match a certain format or that the lat / long given is outside of the bounding box of the dataset. 

To test this, you can enter text and lat / longs into the Gimme box in the Climate Stripes story: http://localhost:3000/item/story-climate-stripes-2

Try a variety of text and numbers to get each of the error messages:

1. ⚠️ Sorry, no matching communities within the extent of this dataset were found.'
2. ⚠️ This point is outside the bounding box of data: latitude between 50.5 – 90, longitude between -180 – 180
3. Lat/long must be in decimal degrees or DMS format, i.e. 65°30'0.56" -140°7'34.45

Closes #189 