### PR TITLE
Updates text for fire prone conditions subtext for the item.

### DIFF
--- a/explorer/assets/items.ts
+++ b/explorer/assets/items.ts
@@ -488,7 +488,7 @@ export default [
     slug: 'story-fire-prone-conditions',
     title: 'Fire-Prone Conditions in Alaska',
     blurb:
-      'Explore how temperature, humidity, precipitation, and wind patterns combine to create conditions favorable for wildfires. Compare recent years to historical climatology.',
+      'Explore how temperature, humidity, and precipitation combine to create conditions favorable for wildfires. Compare recent years to historical climatology.',
     tags: ['Climate', 'Wildfire', 'Temperature', 'Precipitation'],
     image: 'story-fire-prone-conditions.png',
   },


### PR DESCRIPTION
This PR updates the subtext for the item "Fire-Prone conditions in Alaska" per review by Charlie. This simply drops the reference to wind since that is not an included portion of this particular story.