### PR TITLE
Change "data is" to "data are" in CMIP6 downscaled data story

### DIFF
--- a/explorer/components/global/StoryCmip6Downscaled.vue
+++ b/explorer/components/global/StoryCmip6Downscaled.vue
@@ -170,7 +170,7 @@ mapStore.setLegendItems(cmip6_downscaled_mapId, cmip6_downscaled_legend)
         Raw outputs from General Circulation Models (GCMs) are helpful to get a
         glimpse into how the climate is likely to change at a global scale, but
         they have limitations. When zooming in on a particular region like
-        Alaska, for example, the data is very coarse (low resolution) and
+        Alaska, for example, the data are very coarse (low resolution) and
         difficult to relate to local communities and areas. This is where
         downscaling helps.
       </p>


### PR DESCRIPTION
I'm usually not super persnickety about "data is" vs. "data are", but we're using the phrase "data are" in two other places in this data story, so best to keep it consistent! My bad.