### PR TITLE
Fix new TypeScript errors

### DIFF
--- a/explorer/components/global/StoryClimateStripes2.vue
+++ b/explorer/components/global/StoryClimateStripes2.vue
@@ -8,7 +8,7 @@ const { $Plotly, $_ } = useNuxtApp()
 import type { Data, ColorBar } from 'plotly.js-dist-min'
 
 interface ExtendedColorBar extends ColorBar {
-  orientation?: 'h' | 'v'
+  orientation: 'h' | 'v'
 }
 
 const apiData = computed<Record<string, any>>(() => dataStore.apiData[endpoint])

--- a/explorer/nuxt.config.ts
+++ b/explorer/nuxt.config.ts
@@ -205,7 +205,7 @@ export default defineNuxtConfig({
     head: {
       noscript: [
         {
-          children: noscriptHtml,
+          innerHTML: noscriptHtml,
         },
       ],
       title: 'Arctic Data Collaborative: ARDAC',


### PR DESCRIPTION
Closes #228.

This PR tweaks two files to fix the TypeScript errors that I mysteriously started encountering today (after rebuilding my global Nuxt environment), which it sounds like Bruce started seeing recently too. This PR does not fix all of the new warnings, just the two errors that were preventing me from starting the webapp.

To test, I ran the webapp and:

- Verified that the climate stripes widget still works as expected here: http://localhost:3000/item/story-climate-stripes-2
- Verified that the NoScript text content shows as expected after I disabled JavaScript support in my browser
