### PR TITLE
Fix first-day-of-month x-axis tick marks in CMIP6 downscaled charts

### DIFF
--- a/explorer/components/Cmip6DownscaledChart.vue
+++ b/explorer/components/Cmip6DownscaledChart.vue
@@ -132,6 +132,12 @@ const buildChart = () => {
       tickangle: 45,
     })
 
+    layout.xaxis = {
+      tickmode: 'array',
+      tickvals: xTickVals,
+      ticktext: xTickLabels,
+    }
+
     const config = getConfig(chartTitle)
 
     $Plotly.newPlot(chartId.value, traces, layout, config)


### PR DESCRIPTION
Closes #226.

This PR fixes the x-axis tick labels on the CMIP6 downscaled charts. I originally had this set up to show the first day of each month on the x-axis, but this functionality was lost when I modified the code to use the shared `getLayout` function (even though most of the code responsible for the new tick marks is was still present, which is why this code diff is so small).

Instead of this:

<img width="2450" height="900" alt="image" src="https://github.com/user-attachments/assets/b53b7fad-6e9e-44cc-b74a-a7f471604d53" />

The charts now look like this (notice the x-axis tick labels):

<img width="2450" height="900" alt="image" src="https://github.com/user-attachments/assets/7d285b65-3b3b-4b53-8e7b-c7c40b0d5b50" />

This applies to the CMIP6 downscaled tasmax, tasmin, and pr charts.